### PR TITLE
[태그 목록 페이지] 태그 목록 API 및 태그 상세 API 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --runInBand --config ./test/jest-e2e.json"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.185.0",

--- a/src/dto/tag-request.dto.ts
+++ b/src/dto/tag-request.dto.ts
@@ -1,11 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsBoolean, IsEnum, IsString, IsUrl } from '@src/common/validator';
 import { TagRequest, TagTypes } from '@src/interfaces/tag.interface';
+import { Transform } from 'class-transformer';
 import { IsOptional } from 'class-validator';
 import { BaseDto } from './base.dto';
 
 export class TagRequestDto extends BaseDto implements TagRequest {
   @IsEnum(TagTypes)
+  @Transform(({ value }) => TagTypes[value])
   @ApiProperty({
     enum: TagTypes,
     description: '태그 종류',

--- a/src/dto/tag.dto.ts
+++ b/src/dto/tag.dto.ts
@@ -1,5 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { Tag, TagTypes } from '@src/interfaces/tag.interface';
+import {
+  ArtistProfile,
+  Tag,
+  TagSearchTypes,
+  TagTypes,
+} from '@src/interfaces/tag.interface';
 import { Exclude, Expose, Transform } from 'class-transformer';
 import { IsInt, IsString } from '@src/common/validator';
 import { IsEnum, IsOptional } from 'class-validator';
@@ -16,6 +21,7 @@ export class LimitDto extends BaseDto {
   })
   limit: number;
 }
+
 export class TagDto extends LimitDto {
   @IsString()
   @ApiProperty({
@@ -30,6 +36,39 @@ export class TagDto extends LimitDto {
   limit = 5;
 }
 
+export class TagListDto extends LimitDto {
+  @IsEnum(TagTypes)
+  @Transform(({ value }) => TagTypes[value])
+  @ApiProperty({
+    enum: TagTypes,
+    description: '태그 종류',
+  })
+  type: TagTypes;
+
+  @IsOptional()
+  @IsEnum(TagSearchTypes)
+  @Transform(({ value }) => TagSearchTypes[value])
+  @ApiProperty({
+    enum: TagSearchTypes,
+    description: '태그 검색 유형',
+    required: false,
+  })
+  stype?: TagSearchTypes;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty({
+    type: String,
+    description: '태그 검색 키워드',
+    required: false,
+  })
+  s?: string;
+
+  @ApiProperty({
+    default: 5,
+  })
+  limit = 5;
+}
 @Exclude()
 export class TagResultDto extends BaseDto implements Tag {
   @Expose()
@@ -40,7 +79,6 @@ export class TagResultDto extends BaseDto implements Tag {
   seq: number;
 
   @Expose()
-  @IsEnum(TagTypes)
   @Transform(({ value }) => (Number.isInteger(value) ? value : parseInt(value)))
   @ApiProperty({
     enum: TagTypes,
@@ -49,7 +87,6 @@ export class TagResultDto extends BaseDto implements Tag {
   type: TagTypes;
 
   @Expose()
-  @IsString()
   @ApiProperty({
     type: String,
     description: '태그 이름',
@@ -75,20 +112,46 @@ export class TagDescriptionDto extends TagResultDto implements Tag {
   seq: number;
 
   @Expose()
-  @IsEnum(TagTypes)
   type: TagTypes;
 
   @Expose()
-  @IsString()
   name: string;
 
   @Expose()
-  @IsString()
   @ApiProperty({
     type: String,
     description: '태그 설명',
   })
   description: string;
+
+  status: boolean;
+
+  isAdult: boolean;
+
+  requester: number;
+}
+
+@Exclude()
+export class TagDetailDto extends TagDescriptionDto implements Tag {
+  @Expose()
+  seq: number;
+
+  @Expose()
+  type: TagTypes;
+
+  @Expose()
+  name: string;
+
+  @Expose()
+  description: string;
+
+  @Expose()
+  @Transform(({ value }) => value?.map((x: ArtistProfile) => x.artistProfile))
+  @ApiProperty({
+    type: [String],
+    description: '원작자의 프로필 링크',
+  })
+  profiles?: ArtistProfile[];
 
   status: boolean;
 

--- a/src/interfaces/tag.interface.ts
+++ b/src/interfaces/tag.interface.ts
@@ -5,6 +5,7 @@ export interface Tag {
   status: boolean;
   isAdult: boolean;
   requester: number;
+  profiles?: ArtistProfile[];
 }
 
 export interface TagRequest {
@@ -32,6 +33,12 @@ export enum TagTypes {
   ATTRIBUTE,
   LANGUAGE,
   EXTRA,
+}
+
+export enum TagSearchTypes {
+  NAME,
+  PROFILE,
+  DESCRIPTION,
 }
 
 export enum ExtraTagTypes {

--- a/src/tag/tag.controller.ts
+++ b/src/tag/tag.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Get, Post, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Post,
+  Query,
+} from '@nestjs/common';
 import {
   ApiBearerAuth,
   ApiBody,
@@ -11,7 +19,9 @@ import { UserProfile } from '@src/interfaces/user.interface';
 import {
   LimitDto,
   TagDescriptionDto,
+  TagDetailDto,
   TagDto,
+  TagListDto,
   TagResultDto,
 } from '@src/dto/tag.dto';
 import { TagService } from './tag.service';
@@ -43,6 +53,35 @@ export class TagController {
     @Query() dto: TagDto,
   ): Promise<TagResultDto[]> {
     const items = await this.tagService.find(user, dto);
+    return items.map((item) => new TagResultDto(item));
+  }
+
+  @Get('detail/:seq')
+  @ApiBearerAuth()
+  @ApiOkResponse({
+    type: TagDetailDto,
+  })
+  async getTagDetail(
+    @Profile() user: UserProfile | null,
+    @Param('seq', ParseIntPipe) seq: number,
+  ): Promise<TagDetailDto> {
+    const item = await this.tagService.findDetail(user, seq);
+    return new TagDetailDto(item);
+  }
+
+  @Get('list')
+  @ApiBearerAuth()
+  @ApiQuery({
+    type: TagListDto,
+  })
+  @ApiOkResponse({
+    type: [TagResultDto],
+  })
+  async getTagList(
+    @Profile() user: UserProfile | null,
+    @Query() dto: TagListDto,
+  ): Promise<TagResultDto[]> {
+    const items = await this.tagService.findList(user, dto);
     return items.map((item) => new TagResultDto(item));
   }
 

--- a/src/tag/tag.module.ts
+++ b/src/tag/tag.module.ts
@@ -1,13 +1,12 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { ArtistProfileEntity } from '@src/entities/artist-profile.entity';
 import { TagEntity } from '@src/entities/tag.entity';
 import { TagController } from './tag.controller';
 import { TagService } from './tag.service';
 
 @Module({
   // 태그 repository 사용
-  imports: [TypeOrmModule.forFeature([TagEntity, ArtistProfileEntity])],
+  imports: [TypeOrmModule.forFeature([TagEntity])],
   controllers: [TagController],
   providers: [TagService],
 })

--- a/src/tag/tag.service.ts
+++ b/src/tag/tag.service.ts
@@ -81,7 +81,7 @@ export class TagService {
   findDetail(user: UserProfile | null, seq: number): Promise<TagEntity> {
     return this.tagRepository
       .createQueryBuilder('tag')
-      .leftJoinAndSelect('tag.profiles', 'profiles')
+      .leftJoinAndSelect('tag.profiles', 'profile')
       .where('tag.status')
       .andWhere(
         `(not tag."is_adult" 
@@ -92,6 +92,7 @@ export class TagService {
         },
       )
       .andWhere('tag.seq = :seq', { seq })
+      .orderBy('profile.seq', 'ASC')
       .getOne();
   }
 

--- a/test/content-details.e2e-spec.ts
+++ b/test/content-details.e2e-spec.ts
@@ -116,7 +116,7 @@ describe('ContentController - details (e2e)', () => {
     testTagArtist = await tagRepository.save(
       new TagEntity({
         type: TagTypes.ARTIST,
-        name: '테스트 작가',
+        name: '컨텐츠-디테일 테스트 작가',
         description: '테스트용 작가입니다.',
         status: true,
         isAdult: false,
@@ -126,7 +126,7 @@ describe('ContentController - details (e2e)', () => {
     testTag = await tagRepository.save(
       new TagEntity({
         type: TagTypes.CHARACTOR,
-        name: '테스트 캐릭터',
+        name: '컨텐츠-디테일 테스트 캐릭터',
         description: '테스트용 캐릭터입니다.',
         status: true,
         isAdult: false,
@@ -135,7 +135,7 @@ describe('ContentController - details (e2e)', () => {
 
     series = await seriesRepository.save(
       new SeriesEntity({
-        title: '테스트 시리즈',
+        title: '컨텐츠-디테일 테스트 시리즈',
       }),
     );
 
@@ -149,7 +149,7 @@ describe('ContentController - details (e2e)', () => {
     contentStatusFalse = await contentRepository.save(
       new ContentEntity({
         createdAt: new Date(),
-        title: '테스트 컨텐츠 2',
+        title: '컨텐츠-디테일 테스트 컨텐츠 2',
         thumbnail: 'http://example.com/image.jpg',
         isAdult: false,
         translateReview: '번역 후기',
@@ -164,7 +164,7 @@ describe('ContentController - details (e2e)', () => {
     content = await contentRepository.save(
       new ContentEntity({
         createdAt: new Date(),
-        title: '테스트 컨텐츠 1',
+        title: '컨텐츠-디테일 테스트 컨텐츠 1',
         thumbnail: 'http://example.com/image.jpg',
         isAdult: false,
         translateReview: '번역 후기',

--- a/test/tag-request.e2e-spec.ts
+++ b/test/tag-request.e2e-spec.ts
@@ -32,6 +32,7 @@ describe('TagController (e2e)', () => {
         TypeOrmModule.forRootAsync({
           useClass: TypeOrmConfigService,
         }),
+        TypeOrmModule.forFeature([ArtistProfileEntity]),
         TagModule,
       ],
       providers: [
@@ -76,25 +77,25 @@ describe('TagController (e2e)', () => {
 
     beforeAll(async () => {
       charatorTag = new TagRequestDto({
-        type: TagTypes.CHARACTOR,
-        name: '테스트 캐릭터',
+        type: TagTypes[TagTypes.CHARACTOR],
+        name: '태그-요청 테스트 캐릭터',
         description: '테스트 캐릭터입니다.',
       });
       artistTag = new TagRequestDto({
-        type: TagTypes.ARTIST,
-        name: '테스트 작가',
+        type: TagTypes[TagTypes.ARTIST],
+        name: '태그-요청 테스트 작가',
         description: '테스트 작가입니다.',
         profiles: ['http://example.com', 'http://test.com'],
       });
       artistTagWithSameProfile = new TagRequestDto({
-        type: TagTypes.ARTIST,
-        name: '테스트 작가 2',
+        type: TagTypes[TagTypes.ARTIST],
+        name: '태그-요청 테스트 작가 2',
         description: '테스트 작가2입니다.',
         profiles: ['http://example.com', 'http://test2.com'],
       });
       artistTagWithoutProfile = new TagRequestDto({
-        type: TagTypes.ARTIST,
-        name: '테스트 작가 2',
+        type: TagTypes[TagTypes.ARTIST],
+        name: '태그-요청 테스트 작가 2',
         description: '테스트 작가2 입니다.',
       });
     });


### PR DESCRIPTION
**PR 설명**
태그 목록 API와 태그 상세 API를 구현하였습니다.

**개발된 기능**
- `GET /tag/detail/:seq`, `GET /tag/list` API 구현

**레퍼런스**
없음
