### PR TITLE
[신고] 컨텐츠 신고 API 추가

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -13,11 +13,10 @@ import { RedisConfigService } from './config/redis.config';
 import { RabbitModule } from './rabbitmq/rabbit.module';
 import { ShutDownService } from './common/event/shutdown.event';
 import { LikesModule } from './likes/like.module';
-import { RabbitMQModule } from '@golevelup/nestjs-rabbitmq';
-import { RabbitConfigService } from '@src/config/rabbit.config';
 import { APP_GUARD, APP_INTERCEPTOR } from '@nestjs/core';
 import { JwtAuthGuard } from './common/guard/jwt-auth.guard';
 import { SeriesModule } from './series/series.module';
+import { ReportModule } from './report/report.module';
 
 @Module({
   imports: [
@@ -34,9 +33,6 @@ import { SeriesModule } from './series/series.module';
     RedisModule.forRootAsync({
       useClass: RedisConfigService,
     }),
-    RabbitMQModule.forRootAsync(RabbitMQModule, {
-      useClass: RabbitConfigService,
-    }),
     // 이하는 API 모듈 일람
     TagModule,
     ContentModule,
@@ -44,6 +40,7 @@ import { SeriesModule } from './series/series.module';
     ProfileImgModule,
     SeriesModule,
     RabbitModule,
+    ReportModule,
   ],
   // 후일 삭제 바람.
   controllers: [AppController],

--- a/src/common/validator/index.ts
+++ b/src/common/validator/index.ts
@@ -5,6 +5,8 @@ import {
   IsUrl as _IsUrl,
   IsEnum as _IsEnum,
   IsBoolean as _IsBoolean,
+  IsEmpty as _IsEmpty,
+  Equals as _Equals,
   ValidationOptions,
 } from 'class-validator';
 import ValidatorJS from 'validator';
@@ -44,5 +46,20 @@ export const IsUrl = (
 export const IsEnum = (entity: object, validationOptions?: ValidationOptions) =>
   _IsEnum(entity, {
     message: `$property가 ENUM에 해당하지 않습니다.`,
+    ...validationOptions,
+  });
+
+export const IsEmpty = (validationOptions?: ValidationOptions) =>
+  _IsEmpty({
+    message: `$property는 공란이어야 합니다.`,
+    ...validationOptions,
+  });
+
+export const Equals = (
+  comparison: any,
+  validationOptions?: ValidationOptions,
+) =>
+  _Equals(comparison, {
+    message: `$property는 특정한 값과 동일해야 합니다.`,
     ...validationOptions,
   });

--- a/src/dto/report.dto.ts
+++ b/src/dto/report.dto.ts
@@ -1,0 +1,77 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
+import { Equals, IsEmpty, IsInt, IsString } from '@src/common/validator';
+import { IsEnum, IsOptional } from 'class-validator';
+import { BaseDto } from './base.dto';
+import {
+  ContentReportType,
+  Report,
+  ReportType,
+  UserReportType,
+} from '@src/interfaces/report.interface';
+
+export class ReportDto extends BaseDto implements Report {
+  @IsEnum(ReportType)
+  @Transform(({ value }) => ReportType[value])
+  @ApiProperty({
+    enum: ReportType,
+    description: '신고 유형',
+  })
+  type: ReportType;
+
+  reportType: ContentReportType | UserReportType;
+
+  @IsEmpty()
+  reporter: number;
+
+  @IsInt()
+  @Transform(({ value }) => parseInt(value))
+  @ApiProperty({
+    type: Number,
+    description: '신고 대상',
+  })
+  target: number;
+
+  @IsOptional()
+  @IsString()
+  @ApiProperty({
+    type: String,
+    description: '신고에 대한 상세 내용',
+    required: false,
+  })
+  detail: string;
+}
+
+export class ReportContentDto extends ReportDto {
+  @Equals(ReportType.CONTENT)
+  type: ReportType;
+
+  @IsEnum(ContentReportType)
+  @Transform(({ value }) => ContentReportType[value])
+  @ApiProperty({
+    enum: ContentReportType,
+    description: '컨텐츠 신고 상세 유형',
+  })
+  reportType: ContentReportType;
+}
+
+export class ReportUserDto extends ReportDto {
+  @Equals(ReportType.USER)
+  type: ReportType;
+
+  @IsEnum(UserReportType)
+  @Transform(({ value }) => UserReportType[value])
+  @ApiProperty({
+    enum: UserReportType,
+    description: '유저 신고 상세 유형',
+  })
+  reportType: UserReportType;
+}
+
+export class ReportResultDto extends BaseDto {
+  @ApiProperty({
+    type: String,
+    description: '결과 메세지',
+  })
+  message: string;
+}

--- a/src/interfaces/report.interface.ts
+++ b/src/interfaces/report.interface.ts
@@ -1,0 +1,27 @@
+export interface Report {
+  type: ReportType;
+  reportType: ContentReportType | UserReportType;
+  target: number;
+  reporter: number;
+  detail: string;
+}
+
+export enum ReportType {
+  CONTENT,
+  USER,
+}
+
+export enum ContentReportType {
+  TRANSLATE_ERROR,
+  ADULT_CONTENT,
+  NOT_ALLOWED_CONTENT,
+  NOT_TRANSLATED,
+  ADVERTISEMENT,
+}
+
+export enum UserReportType {
+  BAD_NICKNAME,
+  BAD_PROFILE_IMG,
+  MACRO_BOT,
+  ADVERTISEMENT_PAPERING,
+}

--- a/src/report/report.controller.ts
+++ b/src/report/report.controller.ts
@@ -1,0 +1,31 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiOkResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { Roles } from '@src/common/decorator/roles.decorator';
+import { User } from '@src/common/decorator/user.decorator';
+import { Role } from '@src/common/enum/roles.enum';
+import { ReportContentDto, ReportResultDto } from '@src/dto/report.dto';
+import { ReportService } from './report.service';
+
+@ApiTags('report')
+@Controller('report')
+export class ReportController {
+  constructor(private readonly reportService: ReportService) {}
+
+  @Post('content')
+  @Roles(Role.USER)
+  @ApiBearerAuth()
+  @ApiBody({ type: ReportContentDto })
+  @ApiOkResponse({ type: ReportResultDto })
+  async getAllTags(
+    @User() user: number,
+    @Body() dto: ReportContentDto,
+  ): Promise<ReportResultDto> {
+    const result = this.reportService.reportContent(user, dto);
+    return new ReportResultDto(result);
+  }
+}

--- a/src/report/report.module.ts
+++ b/src/report/report.module.ts
@@ -1,0 +1,16 @@
+import { RabbitMQModule } from '@golevelup/nestjs-rabbitmq';
+import { Module } from '@nestjs/common';
+import { RabbitConfigService } from '@src/config/rabbit.config';
+import { ReportController } from './report.controller';
+import { ReportService } from './report.service';
+
+@Module({
+  imports: [
+    RabbitMQModule.forRootAsync(RabbitMQModule, {
+      useClass: RabbitConfigService,
+    }),
+  ],
+  controllers: [ReportController],
+  providers: [ReportService],
+})
+export class ReportModule {}

--- a/src/report/report.service.ts
+++ b/src/report/report.service.ts
@@ -1,0 +1,26 @@
+import { AmqpConnection } from '@golevelup/nestjs-rabbitmq';
+import { Injectable } from '@nestjs/common';
+import { ReportContentDto, ReportResultDto } from '@src/dto/report.dto';
+
+@Injectable()
+export class ReportService {
+  constructor(private readonly amqpConnection: AmqpConnection) {}
+
+  reportContent(user: number, dto: ReportContentDto): ReportResultDto {
+    dto.reporter = user;
+    try {
+      this.amqpConnection.publish<ReportContentDto>(
+        'fanfixiv.admin',
+        'main.report',
+        dto,
+      );
+      return new ReportResultDto({
+        message: '신고가 성공적으로 완료되었습니다.',
+      });
+    } catch (e) {
+      return new ReportResultDto({
+        message: '신고가 실패하였습니다.',
+      });
+    }
+  }
+}

--- a/src/tag/tag.controller.ts
+++ b/src/tag/tag.controller.ts
@@ -66,6 +66,7 @@ export class TagController {
   @Roles(Role.USER)
   @ApiBearerAuth()
   @ApiBody({ type: TagRequestDto })
+  @ApiOkResponse({ type: TagDescriptionDto })
   async tagRequest(
     @User() user: number,
     @Body() dto: TagRequestDto,

--- a/test/report.e2e-spec.ts
+++ b/test/report.e2e-spec.ts
@@ -1,0 +1,95 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import {
+  ClassSerializerInterceptor,
+  INestApplication,
+  ValidationPipe,
+} from '@nestjs/common';
+import * as request from 'supertest';
+import { ReportController } from '@src/report/report.controller';
+import { ReportService } from '@src/report/report.service';
+import {
+  ContentReportType,
+  ReportType,
+} from '@src/interfaces/report.interface';
+import { JwtStrategy } from '@src/common/strategy/jwt.strategy';
+import { APP_INTERCEPTOR } from '@nestjs/core';
+
+describe('ReportController (e2e)', () => {
+  let app: INestApplication;
+  let module: TestingModule;
+
+  beforeAll(async () => {
+    module = await Test.createTestingModule({
+      controllers: [ReportController],
+      providers: [
+        JwtStrategy,
+        {
+          provide: APP_INTERCEPTOR,
+          useClass: ClassSerializerInterceptor,
+        },
+      ],
+    })
+      .useMocker((token) => {
+        if (token === ReportService) {
+          return {
+            reportContent: jest.fn().mockReturnValue({
+              message: '신고가 성공적으로 완료되었습니다.',
+            }),
+          };
+        }
+      })
+      .compile();
+
+    app = module.createNestApplication();
+
+    app.useGlobalPipes(new ValidationPipe({ transform: true }));
+
+    await app.init();
+  });
+
+  describe('/report/content (POST)', () => {
+    let result: Record<string, any>;
+
+    beforeAll(async () => {
+      result = {
+        message: '신고가 성공적으로 완료되었습니다.',
+      };
+    });
+
+    test('200', () => {
+      const body = {
+        type: ReportType[ReportType.CONTENT],
+        reportType: ContentReportType.TRANSLATE_ERROR,
+        target: 0,
+        detail: '테스트 신고입니다.',
+      };
+
+      return request(app.getHttpServer())
+        .post(`/report/content`)
+        .set('Authorization', 'Bearer ADULT')
+        .send(body)
+        .expect(201)
+        .expect(result);
+    });
+
+    test('400', () => {
+      const body = {
+        type: ReportType[ReportType.CONTENT],
+        reportType: ContentReportType.TRANSLATE_ERROR,
+        target: 'test',
+        detail: '테스트 신고입니다.',
+      };
+
+      return request(app.getHttpServer())
+        .post(`/report/content`)
+        .set('Authorization', 'Bearer ADULT')
+        .send(body)
+        .expect(400);
+    });
+  });
+
+  afterAll(async () => {
+    await app.close();
+    await module.close();
+  });
+});

--- a/test/report.e2e-spec.ts
+++ b/test/report.e2e-spec.ts
@@ -11,7 +11,6 @@ import {
   ContentReportType,
   ReportType,
 } from '@src/interfaces/report.interface';
-import { JwtStrategy } from '@src/common/strategy/jwt.strategy';
 import { APP_INTERCEPTOR } from '@nestjs/core';
 
 describe('ReportController (e2e)', () => {
@@ -22,7 +21,6 @@ describe('ReportController (e2e)', () => {
     module = await Test.createTestingModule({
       controllers: [ReportController],
       providers: [
-        JwtStrategy,
         {
           provide: APP_INTERCEPTOR,
           useClass: ClassSerializerInterceptor,


### PR DESCRIPTION
**PR 설명**
컨텐츠 신고 API를 구현하였습니다. 추가적인 Queue가 MQ에 추가되었으므로 주의 바랍니다.

**개발된 기능**
- `GET /report/content` API 구현

**레퍼런스**
- https://www.npmjs.com/package/@golevelup/nestjs-rabbitmq